### PR TITLE
Rename some mixtures to be more consistent

### DIFF
--- a/src/rainbow/mixtures.py
+++ b/src/rainbow/mixtures.py
@@ -24,7 +24,7 @@ for dataset in datasets.RAINBOW_DATASETS.values():
             continue
 
         t5.data.MixtureRegistry.add(
-            f"{dataset.name}_{size}_rainbow_equal",
+            f"{dataset.name}_{size}_rainbow_equal_mixture",
             [f"{dataset.name}_{size}_task"]
             + [
                 f"{other_dataset.name}_task"
@@ -35,7 +35,7 @@ for dataset in datasets.RAINBOW_DATASETS.values():
         )
 
         t5.data.MixtureRegistry.add(
-            f"{dataset.name}_{size}_rainbow_proportional",
+            f"{dataset.name}_{size}_rainbow_proportional_mixture",
             [f"{dataset.name}_{size}_task"]
             + [
                 f"{other_dataset.name}_task"


### PR DESCRIPTION
All the mixtures except the leave-one-task-out mixtures end with
the substring "_mixture". Add this suffix to the leave-one-task-out
mixtures to make the naming more consistent.