### PR TITLE
Fix bug in knowledge graph tasks

### DIFF
--- a/src/rainbow/tasks.py
+++ b/src/rainbow/tasks.py
@@ -70,9 +70,13 @@ for dataset in datasets.KNOWLEDGE_GRAPH_DATASETS.values():
             )
 
             if direction == "forward":
-                predicate = lambda x: x["targets"].startswith("<object>")
+                predicate = lambda x: tf.strings.regex_full_match(
+                    x["targets"], r"^<object>.*"
+                )
             elif direction == "backward":
-                predicate = lambda x: x["targets"].startswith("<subject>")
+                predicate = lambda x: tf.strings.regex_full_match(
+                    x["targets"], r"^<subject>.*"
+                )
             elif direction == "bidirectional":
                 predicate = lambda x: True
             else:


### PR DESCRIPTION
To filter the knowledge graph datasets, we have to use tensorflow
string operations rather than native python ones.