### PR TITLE
Fix bug writing multiple CSV headers in ConceptNet preprocessing

### DIFF
--- a/src/rainbow/preparation/conceptnet.py
+++ b/src/rainbow/preparation/conceptnet.py
@@ -122,7 +122,9 @@ class ConceptNetPreparer(preparer.Preparer):
                                 fieldnames=["index", "inputs", "targets"],
                                 dialect="unix",
                             )
-                            writer.writeheader()
+                            if file_idx == 0:
+                                # only write the header once
+                                writer.writeheader()
 
                             reader = csv.reader(src_gunzipped, delimiter="\t")
 


### PR DESCRIPTION
When preprocessing ConceptNet, a header gets written after the
start of each new file processed for the same split. Make sure that
the header is only written once by checking whether the current file
being processed is the first one for the split.