### PR TITLE
Make the split for bin/fine-tune.py configurable

### DIFF
--- a/bin/fine-tune.py
+++ b/bin/fine-tune.py
@@ -32,6 +32,12 @@ PRETRAINED_MODELS = {
 @click.argument("mixture", type=str)
 @click.argument("results_dir", type=str)
 @click.option(
+    "--split",
+    type=str,
+    default="train",
+    help="The split on which to train. Defaults to 'train'.",
+)
+@click.option(
     "--pretrained-model",
     type=str,
     default="3B",
@@ -102,6 +108,7 @@ PRETRAINED_MODELS = {
 def fine_tune(
     mixture: str,
     results_dir: str,
+    split: str,
     pretrained_model: str,
     n_steps: int,
     learning_rate: float,
@@ -157,6 +164,7 @@ def fine_tune(
         mixture_or_task_name=mixture,
         pretrained_model_dir=pretrained_model,
         finetune_steps=n_steps,
+        split=split,
     )
 
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 Click==7.0
-t5[gcp]==0.1.7
+t5[gcp]==0.6.2
 tensorflow==1.15.2
 tqdm==4.41.1


### PR DESCRIPTION
Make the split for bin/fine-tune.py configurable so that we can
train WinoGrande on the different training splits. This change
requires updating the T5 library version to a newer one which
allows configuration of the split passed to the finetune method.